### PR TITLE
Add support for LSST schemas. Fixup `Schema` class and related.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## \[Unreleased\]
 
 <!-- (none) -->
+
+### Added
+
+- Support for the LSST alert schema.
+- `types_.Schema._from_yaml` class method and the related helpers `_local_schema_helper` and
+  `_lsst_schema_helper`.
+- `types_.Schema.schemaless_alert_bytes` bool indicating whether the alert bytes are schemaless
+  and thus a `types_.Schema.definition` is required in order to serialize and deserialize them.
+- `types_.Schama.manifest` containing the schemas.yml file loaded as a list of dicts.
+- `types_.Schema.filter_map`, moved from the schema map's "FILTER_MAP".
+- `Schema.origin` and schema-map key name "SCHEMA_ORIGIN" (see Changed).
+- `types_.Schema.definition`. Not actually new, but repurposed (see Changed, Removed).
+
 ### Changed
 
-- Make `Alert` method private, `add_id_attributes` -> `_add_id_attributes`.
+- Changed some schema-map keys to include an underscore for clarity, e.g., "magerr" -> "mag_err"
+  (breaking change).
+- Change method to private `Alert.add_id_attributes` -> `Alert._add_id_attributes`.
+- Changed attribute name `types_.Schema.definition` -> `Schema.origin`. Related, changed
+  schema-map key name "SURVEY_SCHEMA" -> "SCHEMA_ORIGIN". Both for clarity.
+- `types_.Schema.definition` is now used to hold the actual schema definition. Currently this only
+  needed for Avro and so holds the dict loaded from the ".avsc" file(s).
 - Update docstrings for clarity and accuracy.
 - Improve type hints.
 - Fix up Sphinx and rst to improve how docs are being rendered.
+
+### Removed
+
+- `types_.Schema.avsc`. Replaced by `types_.Schema.definition`.
+- Schema-map keys "SURVEY_SCHEMA" (replaced), "TOPIC_SYNTAX" (dropped), "FILTER_MAP" (moved).
 
 ## \[v0.3.4\] - 2024-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Schema.origin` and schema-map key name "SCHEMA_ORIGIN" (see Changed).
 - `types_.Schema.definition`. Not actually new, but repurposed (see Changed, Removed).
 
+### Fixed
+
+- Don't let `Subscription._set_topic` clobber an existing topic attribute. This was preventing the user
+  from creating a subscription attached to a topic in a different project.
+
 ### Changed
 
 - Changed some schema-map keys to include an underscore for clarity, e.g., "magerr" -> "mag_err"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support for the LSST alert schema.
 - `types_.Schema._from_yaml` class method and the related helpers `_local_schema_helper` and
   `_lsst_schema_helper`.
+- Dependency on `lsst-alert-packet` package for the `_lsst_schema_helper`.
 - `types_.Schema.schemaless_alert_bytes` bool indicating whether the alert bytes are schemaless
   and thus a `types_.Schema.definition` is required in order to serialize and deserialize them.
 - `types_.Schama.manifest` containing the schemas.yml file loaded as a list of dicts.

--- a/docs/source/for-developers/add-new-schema-map.md
+++ b/docs/source/for-developers/add-new-schema-map.md
@@ -1,0 +1,59 @@
+# Add a schema map
+
+This page contains instructions for adding a new schema map.
+
+A "schema map" maps our generic field names (keys) to the corresponding name used by the survey (values).
+Pitt-Google defines this set of generic field names so that we can write code that can process
+different surveys without having to worry that one survey might call the (e.g.,) time field "MJD" while
+another calls it "midPointTai". This map is what makes the :meth:`pittgoogle.alert.Alert.get` method work.
+
+Currently, we define schema maps on a per-survey basis. :meth:`pittgoogle.types_.Schema.map` will load
+the yaml file for the survey :meth:`pittgoogle.types_.Schema.survey` and return it as a dictionary.
+If you need something different, a more significant refactor will be required (left as an exercise
+for the reader).
+
+## Add a schema map for a new survey
+
+*pittgoogle/schemas/maps* is the directory containing the schema maps as yaml files.
+
+To add a schema map, make a copy of the file *pittgoogle/schemas/maps/TEMPLATE.yml* and alter it.
+
+
+### How to use the TEMPLATE.yml file
+
+*pittgoogle/schemas/maps/TEMPLATE.yml* : Make a copy of this file and name it using the syntax
+*<survey_name>.yml*.
+
+Alter the new file, keeping these important things to keep in mind:
+
+- These key/value pairs exist to make it easier for users (which may be anyone from Pitt-Google
+  Broker developers to end-user scientists) to write one piece of code that can process multiple surveys.
+- The keys should be used as-is (but see below for excluding or adding keys). Changing a key's
+  spelling could make things difficult for the user.
+- Our schema maps support nested fields. The values in your new yaml file should be given as strings
+  (for top-level fields) or lists of strings (for nested fields).
+- Values given in the *TEMPLATE.yml* file are only examples or descriptions and should be substituted
+  with new values appropriate for the new survey.
+- While a key's *name* is fixed, we do not explicitly define how the key is to be interpreted --
+  there is no ground-truth answer to the question, "Which LSST field should I assign as the 'flux'?".
+- Comments are left in *TEMPLATE.yml* that note the typical data types and interpretations for each field
+  to help guide your decisions.
+- Try to make decisions that result in schema maps that are conceptually consistent across surveys.
+
+### Excluding or adding field names (keys) from the set of Pitt-Google generics
+
+Excluding fields : If your survey/schema does not need a particular key, that key does does not need to
+be included in your new schema map's yaml file. There's not much code in ``pittgoogle-client`` itself
+that cares what these key/value pairs actually are. Notable exceptions *may* include the survey name,
+schema origin, and the IDs.
+
+Adding fields : New keys can be added, but please do two sanity checks first.
+
+1. Is there an existing key that can suite my needs? (if yes, stop)
+2. How would this new key be interpreted if/when used with a different survey? Will it be useful or
+   at least neutral (go ahead), or will it cause confusion (stop, reconsider the key's name and purpose,
+   try to improve it)?
+
+**If you define a new key, be sure to add it to the *TEMPLATE.yml* file.**
+
+You may also want to update existing yaml files so the new key can be used with those surveys.

--- a/docs/source/for-developers/add-new-schema-map.md
+++ b/docs/source/for-developers/add-new-schema-map.md
@@ -18,7 +18,6 @@ for the reader).
 
 To add a schema map, make a copy of the file *pittgoogle/schemas/maps/TEMPLATE.yml* and alter it.
 
-
 ### How to use the TEMPLATE.yml file
 
 *pittgoogle/schemas/maps/TEMPLATE.yml* : Make a copy of this file and name it using the syntax

--- a/docs/source/for-developers/add-new-schema.md
+++ b/docs/source/for-developers/add-new-schema.md
@@ -21,7 +21,8 @@ those of a :class:`pittgoogle.types_.Schema`. The ``helper`` field must point to
 the new schema definition; more information below.
 
 Case 1: The schema definition is not *needed* in order to deserialize the alert bytes. This is true for
-all Json and the Avro streams which attach the schema in the data header. Set ``schemaless_alert_bytes='false'``. Leave ``helper`` and ``path`` as defaults.
+all Json and the Avro streams which attach the schema in the data header. Set
+``schemaless_alert_bytes='false'``. Leave ``helper`` and ``path`` as defaults.
 
 The rest of the cases assume the schema definition is required. This is true for "schemaless" Avro streams
 which do not attach the schema to the data packet. Set ``schemaless_alert_bytes='true'``

--- a/docs/source/for-developers/add-new-schema.md
+++ b/docs/source/for-developers/add-new-schema.md
@@ -1,0 +1,58 @@
+# Add a new schema to the registry
+
+This page contains instructions for adding a new schema to the registry so that it can be loaded
+using :meth:`pittgoogle.registry.Schemas.get` and used to serialize and deserialize the alert bytes.
+You will need to update at least the "Required" files listed below, and potentially one or more of the
+others. The schema format is expected to be either Avro or Json.
+
+First, a naming guideline:
+
+- Schema names are expected to start with the name of the survey. If the survey has more than one schema,
+  the survey name should be followed by a "." and then schema-specific specifier(s).
+
+## Required
+
+### pittgoogle/registry_manifests/schemas.yml
+
+*pittgoogle/registry_manifests/schemas.yml* is the manifest of registered schemas.
+
+Add a new section to the manifest following the template provided there. The fields are the same as
+those of a :class:`pittgoogle.types_.Schema`. The ``helper`` field must point to code that can find and load
+the new schema definition; more information below.
+
+Case 1: The schema definition is not *needed* in order to deserialize the alert bytes. This is true for
+all Json and the Avro streams which attach the schema in the data header. Set ``schemaless_alert_bytes='false'``. Leave ``helper`` and ``path`` as defaults.
+
+The rest of the cases assume the schema definition is required. This is true for "schemaless" Avro streams
+which do not attach the schema to the data packet. Set ``schemaless_alert_bytes='true'``
+
+Case 2: You can write some code that will get the schema definition from an external repository. You will
+probably need to write your own ``helper`` method (more below). Follow ``lsst`` as an example. This is
+preferable to Case 3 because it's usually easier to access new schema versions as soon as the survey
+releases them.
+
+Case 3: You want to include schema definition files with the ``pittgoogle-client`` package. Follow
+``elasticc`` as an example. (1) Commit the files to the repo under the *pittgoogle/schemas* directory. It
+is recommended that the main file name follow the syntax "\<schema_name\>.avsc". (2) Point the ``path``
+field at the new file, relative to the repo root. (3) If you've followed the recommendations, the default
+``helper`` should work, but you should check (more below). If you need to implement your own helper, do it.
+
+## Potentially Required
+
+### pittgoogle/types_.py
+
+*pittgoogle/types_.py* is the file containing the :class:`pittgoogle.types_.Schema` class.
+
+A "helper" method must exist in :class:`pittgoogle.types_.Schema` that can find and load your new schema
+definition. The ``helper`` field in the yaml manifest (above) must be set to the name of this method. If a
+suitable helper method does not already already exist for your schema, add one to this file by following
+existing helpers like :meth:`pittgoogle.types_.Schema._local_schema_helper` as examples. **If your helper
+method requires a new dependency, be sure to add it following
+:doc:`/main/for-developers/manage-dependencies-poetry`.**
+
+### pittgoogle/schemas/maps/
+
+*pittgoogle/schemas/maps/* is the directory containing our schema maps.
+
+If you are adding a schema for a survey that does not yet have a schema map defined, you will need to add
+a yaml file to define it. See :doc:`add-new-schema-map`.

--- a/docs/source/for-developers/add-new-schema.md
+++ b/docs/source/for-developers/add-new-schema.md
@@ -33,15 +33,20 @@ releases them.
 
 Case 3: You want to include schema definition files with the ``pittgoogle-client`` package. Follow
 ``elasticc`` as an example. (1) Commit the files to the repo under the *pittgoogle/schemas* directory. It
-is recommended that the main file name follow the syntax "\<schema_name\>.avsc". (2) Point the ``path``
-field at the new file, relative to the repo root. (3) If you've followed the recommendations, the default
-``helper`` should work, but you should check (more below). If you need to implement your own helper, do it.
+is recommended that the main filename follow the syntax "<schema_name>.avsc". (2) Point ``path``
+at the main file, relative to the package root. If the Avro schema is split into multiple files, you
+usually only need to point to the main one. (3) If you've followed the recommendations then the default
+``helper`` should work, but you should check (more below). If you need to implement your own helper
+or update the existing, do it.
 
 ## Potentially Required
 
 ### pittgoogle/types_.py
 
 *pittgoogle/types_.py* is the file containing the :class:`pittgoogle.types_.Schema` class.
+
+If ``schemaless_alert_bytes='false'``, the defaults (mostly null/None) should work and you can ignore
+this file (skip to the next section).
 
 A "helper" method must exist in :class:`pittgoogle.types_.Schema` that can find and load your new schema
 definition. The ``helper`` field in the yaml manifest (above) must be set to the name of this method. If a

--- a/docs/source/for-developers/index.rst
+++ b/docs/source/for-developers/index.rst
@@ -5,6 +5,8 @@ For Developers
     :maxdepth: 1
 
     setup-environment
+    add-new-schema
+    add-new-schema-map
     manage-dependencies-poetry
     build-docs-sphinx
     release-new-version

--- a/pittgoogle/pubsub.py
+++ b/pittgoogle/pubsub.py
@@ -239,7 +239,7 @@ class Topic:
             avro_schema = None
         else:
             if alert.schema.survey in ["elasticc"]:
-                avro_schema = alert.schema.avsc
+                avro_schema = alert.schema.definition
             else:
                 avro_schema = None
 

--- a/pittgoogle/pubsub.py
+++ b/pittgoogle/pubsub.py
@@ -382,8 +382,9 @@ class Subscription:
             )
             raise PubSubInvalid(msg)
 
-        # set the topic
-        self.topic = Topic.from_path(connected_topic_path)
+        # if the topic isn't already set, do it now
+        if self.topic is None:
+            self.topic = Topic.from_path(connected_topic_path)
         LOGGER.debug("topic validated")
 
     def delete(self) -> None:

--- a/pittgoogle/pubsub.py
+++ b/pittgoogle/pubsub.py
@@ -296,8 +296,8 @@ class Subscription:
             # make sure the subscription exists and we can connect to it. create it if necessary
             subscription.touch()
 
-        Pull a small batch of alerts. Helpful for testing. (For long-runnining listeners, see
-        :class:`pittgoogle.Consumer`.)
+        Pull a small batch of alerts. Helpful for testing. (Not recommended for long-running listeners;
+        use :class:`pittgoogle.pubsub.Consumer` instead.)
 
         .. code-block:: python
 

--- a/pittgoogle/registry.py
+++ b/pittgoogle/registry.py
@@ -34,11 +34,37 @@ class ProjectIds:
 
 @define(frozen=True)
 class Schemas:
-    """Registry of schemas used by Pitt-Google."""
+    """Registry of schemas used by Pitt-Google.
+
+    Example:
+
+    .. code-block:: python
+
+        # View list of registered schema names.
+        pittgoogle.Schemas.names
+
+        # Load a schema (choose a name from above and substitute it below).
+        schema = pittgoogle.Schemas.get(schema_name="ztf")
+
+
+    For Developers:
+
+    Register a New Schema
+
+    Schemas are defined in the yaml file [registry_manifests/schemas.yml](registry_manifests/schemas.yml).
+    To register a new schema, add a section to that file.
+    The fields are the same as those of a :class:`pittgoogle.types_.Schema`.
+    The `helper` field value must be the name of a valid `*_helper` method in :class:`pittgoogle.types_.Schema`.
+    If a suitable method does not already exist for your schema, add one by following the default as an example.
+    If your new helper method requires a new dependency, be sure to add it following
+    :doc:`/main/for-developers/manage-dependencies-poetry`
+    If you want to include your schema's ".avsc" file with the pittgoogle package, be sure to
+    commit the file(s) to the repo under the "schemas" directory.
+    """
 
     @classmethod
     def get(cls, schema_name: str) -> types_.Schema:
-        """Return the registered schema called `schema_name`.
+        """Return the schema registered with name `schema_name`.
 
         Raises
         ------
@@ -48,18 +74,13 @@ class Schemas:
         for schema in SCHEMA_MANIFEST:
             if schema["name"] != schema_name:
                 continue
-
-            return types_.Schema(
-                name=schema["name"],
-                description=schema["description"],
-                path=PACKAGE_DIR / schema["path"] if schema["path"] is not None else None,
-            )
+            return types_.Schema.from_yaml(schema_dict=schema)
 
         raise SchemaNotFoundError(
             f"{schema_name} not found. for a list of valid names, use `pittgoogle.Schemas.names()`."
         )
 
-    @classmethod
-    def names(cls) -> list[str]:
+    @staticmethod
+    def names() -> list[str]:
         """Return the names of all registered schemas."""
         return [schema["name"] for schema in SCHEMA_MANIFEST]

--- a/pittgoogle/registry_manifests/schemas.yml
+++ b/pittgoogle/registry_manifests/schemas.yml
@@ -1,11 +1,6 @@
-# Guidelines:
-# - Schema names must start with the name of the survey. If the survey has more than one schema
-#   the survey name should be followed by a "." and then a schema-specific specifier(s).
-# - If a schema file is also being registered (path key), it is recommended that the file have the
-#   same name (path stem) as the schema. Avro is the only file type currently implemented, and the file name
-#   must end with ".avsc".
-# - The path must be relative to the package directory or null if no schema file is being registered.
-#
+# Add an entry to this yaml file to register a new schema.
+# A template is given below for convenience.
+# See docs/source/for-developers/add-new-schema.md for more information.
 #
 # # TEMPLATE
 # - name: ''

--- a/pittgoogle/registry_manifests/schemas.yml
+++ b/pittgoogle/registry_manifests/schemas.yml
@@ -8,24 +8,55 @@
 #
 #
 # # TEMPLATE
-# # See the registry.Schemas docstring for an explanation of the fields.
-# - name: ""
-#   description: ""
-#   helper: ""
-#   path: ""
+# - name: ''
+#   description: ''
+#   helper: '_local_schema_helper'
+#   path: ''
+#   schemaless_alert_bytes: false
+#   filter_map:
+#     1: ''
+#     2: ''
 #
 # ELASTICC alerts
-- name: "elasticc.v0_9_1.alert"
-  description: "Avro schema of alerts published by ELAsTiCC."
-  path: "schemas/elasticc/elasticc.v0_9_1.alert.avsc"
+- name: 'elasticc.v0_9_1.alert'
+  description: 'Avro schema of alerts published by ELAsTiCC.'
+  origin: 'https://github.com/LSSTDESC/elasticc/tree/main/alert_schema'
+  helper: '_local_schema_helper'
+  path: 'schemas/elasticc/elasticc.v0_9_1.alert.avsc'
+  schemaless_alert_bytes: true
+#
 # ELASTICC classifications
-- name: "elasticc.v0_9_1.brokerClassification"
-  description: "Avro schema of alerts to be sent to DESC containing classifications of ELAsTiCC alerts."
-  path: "schemas/elasticc/elasticc.v0_9_1.brokerClassification.avsc"
-# Rubin alerts
-- name: ""  # [TODO]
-  description:
+- name: 'elasticc.v0_9_1.brokerClassification'
+  description: 'Avro schema of alerts to be sent to DESC containing classifications of ELAsTiCC alerts.'
+  origin: 'https://github.com/LSSTDESC/elasticc/tree/main/alert_schema'
+  helper: '_local_schema_helper'
+  path: 'schemas/elasticc/elasticc.v0_9_1.brokerClassification.avsc'
+  schemaless_alert_bytes: true
+#
+# LSST alerts
+# - name: 'lsst.v7_1.alert'
+- name: 'lsst.v<MAJOR>_<MINOR>.alert'
+  description: ''  # [TODO]
+  origin: 'https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema'
+  helper: '_lsst_schema_helper'
+  schemaless_alert_bytes: true
+  # [FIXME] filter_map is probably int -> {u, g, r, i, z, y}. Check for sure and fill in below
+  filter_map:
+    1: ''
+    2: ''
+    3: ''
+    4: ''
+    5: ''
+    6: ''
+#
 # ZTF alerts
-- name: "ztf"
-  description: "ZTF schema. The ZTF survey publishes alerts in Avro format with the schema attached in the header. Pitt-Google publishes ZTF alerts in json format. This schema covers both cases."
+- name: 'ztf'
+  description: 'ZTF schema. The ZTF survey publishes alerts in Avro format with the schema attached in the header. Pitt-Google publishes ZTF alerts in json format. This schema covers both cases.'
+  origin: 'https://zwickytransientfacility.github.io/ztf-avro-alert/schema.html'
+  helper: '_local_schema_helper'
+  schemaless_alert_bytes: false
   path: null
+  filter_map:
+    1: g
+    2: r
+    3: i

--- a/pittgoogle/schemas/maps/TEMPLATE.yml
+++ b/pittgoogle/schemas/maps/TEMPLATE.yml
@@ -1,0 +1,28 @@
+# To add a new schema map, make a copy of this template file and alter it.
+# See docs/source/for-developers/add-new-schema-map.md for more information.
+#
+# Survey name and schema origin.
+SURVEY: 'lsst'
+SCHEMA_ORIGIN: 'https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema'
+#
+# IDs.
+alertid: alertId  # str or int (typical type for the value of the field that both of these names represent)
+objectid: [diaObject, diaObjectId]  # str or int
+sourceid: [diaSource, diaSourceId]  # str or int
+#
+# Everything else.
+cutout_difference: cutoutDifference  # bytes (image stamp)
+cutout_science: cutoutScience  # bytes (image stamp)
+cutout_template: cutoutTemplate  # bytes (image stamp)
+dec: decl  # float
+filter: filterName  # int (`Schema.filter_map` often maps this to the filter's common name, like 2 -> 'r')
+flux: psFlux  # float (typically PSF flux, not aperture)
+fluxerr: psFluxErr  # float
+mag: magpsf  # float (typically PSF mag, not aperture)
+magerr: sigmapsf  # float
+magzp: magzpsci  # float (magnitude zero point)
+mjd: midPointTai  # float
+prv_forced_sources: prvDiaForcedSources  # record or array
+prv_sources: prvDiaSources  # record or array
+ra: ra  # float
+source: diaSource  # record or array

--- a/pittgoogle/schemas/maps/TEMPLATE.yml
+++ b/pittgoogle/schemas/maps/TEMPLATE.yml
@@ -15,6 +15,7 @@ source: diaSource  # record
 object: diaObject  # record
 prv_forced_sources: prvDiaForcedSources  # array of records
 prv_sources: prvDiaSources  # array of records
+prv_nondetect_limits: prvDiaNondetectionLimits  # array of records
 ss_object: ssObject  # record
 #
 # Everything else.

--- a/pittgoogle/schemas/maps/TEMPLATE.yml
+++ b/pittgoogle/schemas/maps/TEMPLATE.yml
@@ -10,19 +10,29 @@ alertid: alertId  # str or int (typical type for the value of the field that bot
 objectid: [diaObject, diaObjectId]  # str or int
 sourceid: [diaSource, diaSourceId]  # str or int
 #
+# Sources and Objects
+source: diaSource  # record
+object: diaObject  # record
+prv_forced_sources: prvDiaForcedSources  # array of records
+prv_sources: prvDiaSources  # array of records
+ss_object: ssObject  # record
+#
 # Everything else.
+# [TODO] Currently can only use each key/value pair to get data from one place, but the same field
+# often exists in multiple places (e.g., source and prv_sources both have mjd data).
+# How to make this more flexible and use it to access both/all data with a given name?
 cutout_difference: cutoutDifference  # bytes (image stamp)
 cutout_science: cutoutScience  # bytes (image stamp)
 cutout_template: cutoutTemplate  # bytes (image stamp)
-dec: decl  # float
-filter: filterName  # int (`Schema.filter_map` often maps this to the filter's common name, like 2 -> 'r')
-flux: psFlux  # float (typically PSF flux, not aperture)
-fluxerr: psFluxErr  # float
-mag: magpsf  # float (typically PSF mag, not aperture)
-magerr: sigmapsf  # float
-magzp: magzpsci  # float (magnitude zero point)
-mjd: midPointTai  # float
-prv_forced_sources: prvDiaForcedSources  # record or array
-prv_sources: prvDiaSources  # record or array
-ra: ra  # float
-source: diaSource  # record or array
+dec: [diaSource, dec]  # float
+dec_err: [diaSource, decErr]  # float
+filter: [diaSource, filterName]  # int (`Schema.filter_map` often maps this to the filter's common name, like 2 -> 'r')
+flux: [diaSource, psFlux]  # float (typically PSF flux, not aperture)
+flux_err: [diaSource, psFluxErr]  # float
+mag: [diaSource, magpsf]  # float (typically PSF mag, not aperture)
+mag_err: [diaSource, sigmapsf]  # float
+mag_zp: [diaSource, magzpsci]  # float (magnitude zero point)
+mjd: [diaSource, midPointTai]  # float
+ra: [diaSource, ra]  # float
+ra_err: [diaSource, raErr]  # float
+snr: [diaSource, snr]  # float

--- a/pittgoogle/schemas/maps/decat.yml
+++ b/pittgoogle/schemas/maps/decat.yml
@@ -1,5 +1,6 @@
+# We are no longer processing this survey. This file is left for reference.
 SURVEY: decat
-SURVEY_SCHEMA: https://github.com/rknop/decat_schema
+SCHEMA_ORIGIN: https://github.com/rknop/decat_schema
 TOPIC_SYNTAX: decat_yyyymmdd_2021A-0113  # replace yyyymmdd with the date
 FILTER_MAP:
   g DECam SDSS c0001 4720.0 1520.0: g
@@ -13,5 +14,5 @@ cutout_science: scicutout
 cutout_template: refcutout
 filter: filter
 mag: mag
-magerr: magerr
-magzp: magzp
+mag_err: magerr
+mag_zp: magzp

--- a/pittgoogle/schemas/maps/elasticc.yml
+++ b/pittgoogle/schemas/maps/elasticc.yml
@@ -1,8 +1,6 @@
 SURVEY: elasticc
-SURVEY_SCHEMA: https://github.com/LSSTDESC/elasticc/tree/main/alert_schema
+SCHEMA_ORIGIN: https://github.com/LSSTDESC/elasticc/tree/main/alert_schema
 SCHEMA_VERSION: v0_9_1
-TOPIC_SYNTAX:
-FILTER_MAP:
 alertid: alertId
 objectid: [diaObject, diaObjectId]
 source: diaSource
@@ -12,10 +10,10 @@ prv_forced_sources: prvDiaForcedSources
 mjd: midPointTai
 filter: filterName
 mag: magpsf
-magerr: sigmapsf
-magzp: magzpsci
+mag_err: sigmapsf
+mag_zp: magzpsci
 flux: psFlux
-fluxerr: psFluxErr
+flux_err: psFluxErr
 ra: ra
 dec: decl
 cutout_science:

--- a/pittgoogle/schemas/maps/lsst.yml
+++ b/pittgoogle/schemas/maps/lsst.yml
@@ -1,0 +1,30 @@
+SURVEY: lsst
+SCHEMA_ORIGIN: 'https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema'
+# [FIXME] Check everything below.
+# IDs
+alertid: alertId
+sourceid: [diaSource, diaSourceId]
+objectid: [diaObject, diaObjectId]
+# Sources and Objects
+source: diaSource
+object: diaObject
+prv_sources: prvDiaSources
+prv_forced_sources: null
+ss_object: ssObject
+# Other
+dec: [diaSource, dec]
+dec_err: [diaSource, decErr]
+filter: [diaSource, band]
+flux: [diaSource, psfFlux]
+flux_err: [diaSource, psfFluxErr]
+mag: null
+mag_err: null
+mag_zp: null
+mjd: [diaSource, midpointMjdTai]
+ra: [diaSource, ra]
+ra_err: [diaSource, raErr]
+snr: [diaSource, snr]
+# No cutouts in the alerts yet.
+cutout_science: null
+cutout_template: null
+cutout_difference: null

--- a/pittgoogle/schemas/maps/lsst.yml
+++ b/pittgoogle/schemas/maps/lsst.yml
@@ -9,9 +9,13 @@ objectid: [diaObject, diaObjectId]
 source: diaSource
 object: diaObject
 prv_sources: prvDiaSources
-prv_forced_sources: null
+prv_forced_sources: prvDiaForcedSources
+prv_nondetect_limits: prvDiaNondetectionLimits
 ss_object: ssObject
 # Other
+cutout_science: cutoutScience
+cutout_template: cutoutTemplate
+cutout_difference: cutoutDifference
 dec: [diaSource, dec]
 dec_err: [diaSource, decErr]
 filter: [diaSource, band]
@@ -24,7 +28,3 @@ mjd: [diaSource, midpointMjdTai]
 ra: [diaSource, ra]
 ra_err: [diaSource, raErr]
 snr: [diaSource, snr]
-# No cutouts in the alerts yet.
-cutout_science: null
-cutout_template: null
-cutout_difference: null

--- a/pittgoogle/schemas/maps/ztf.yml
+++ b/pittgoogle/schemas/maps/ztf.yml
@@ -1,5 +1,5 @@
 SURVEY: ztf
-SURVEY_SCHEMA: https://zwickytransientfacility.github.io/ztf-avro-alert/schema.html
+SCHEMA_ORIGIN: https://zwickytransientfacility.github.io/ztf-avro-alert/schema.html
 TOPIC_SYNTAX: ztf_yyyymmdd_programid1  # replace yyyymmdd with the date
 FILTER_MAP:
   1: g
@@ -14,5 +14,5 @@ cutout_science: cutoutScience
 cutout_template: cutoutTemplate
 filter: fid
 mag: magpsf
-magerr: sigmapsf
-magzp: magzpsci
+mag_err: sigmapsf
+mag_zp: magzpsci

--- a/pittgoogle/types_.py
+++ b/pittgoogle/types_.py
@@ -4,7 +4,6 @@ import datetime
 import importlib.resources
 import logging
 from pathlib import Path
-from typing import Optional
 
 import fastavro
 import yaml
@@ -18,15 +17,58 @@ PACKAGE_DIR = importlib.resources.files(__package__)
 class Schema:
     """Class for an individual schema.
 
-    This class is not intended to be used directly.
-    Use :class:`pittgoogle.Schemas` instead.
+    This class is not intended to be used directly. Use :class:`pittgoogle.Schemas` instead.
     """
 
+    """The name of the schema."""
     name: str = field()
+    """The description of the schema."""
     description: str = field()
+    """Name of the `Schema` helper method used to load the schema."""
+    _helper: str = field(default="_local_avsc_helper")
+    """Path where the helper can find the schema."""
     path: Path | None = field(default=None)
+    """Mapping of Pitt-Google's generic field names to survey-specific field names."""
     _map: dict | None = field(default=None, init=False)
-    _avsc: dict | None = field(default=None, init=False)
+    """The Avro schema loaded by the helper or None if no Avro schema exists."""
+    avsc: dict | None = field(default=None, init=False)
+
+    @classmethod
+    def from_yaml(cls, schema_dict: dict) -> "Schema":
+        # initialize the class, then let the helper finish up
+        schema = cls(**schema_dict)
+        helper = getattr(cls, schema._helper)
+        schema = helper(schema)
+        return schema
+
+    @staticmethod
+    def _local_avsc_helper(schema: "Schema") -> "Schema":
+        """Resolve `schema.path`. If it points to a valid ".avsc" file, load it into `schema.avsc`."""
+        # Resolve the path. If it is not None, this helper expects it to be the path to
+        # a ".avsc" file relative to the pittgoogle package directory.
+        schema.path = PACKAGE_DIR / schema.path if schema.path is not None else None
+
+        # Load the avro schema, if the file exists.
+        invalid_path = (
+            (schema.path is None) or (schema.path.suffix != ".avsc") or (not schema.path.is_file())
+        )
+        if invalid_path:
+            schema.avsc = None
+        else:
+            schema.avsc = fastavro.schema.load_schema(schema.path)
+
+        return schema
+
+    @staticmethod
+    def _lsst_avsc_helper(schema: "Schema") -> "Schema":
+        """Resolve `schema.path`. If it points to a valid ".avsc" file, load the Avro schema."""
+        import lsst.alert.packet.schema
+
+        major, minor = schema.path.split(".")  # [FIXME]
+        schema.path = lsst.alert.packet.schema.get_schema_path(major, minor)
+        schema.avsc = lsst.alert.packet.schema.Schema.from_file(schema.path)
+
+        return schema
 
     @property
     def survey(self) -> str:
@@ -49,32 +91,37 @@ class Schema:
                 raise ValueError(f"no schema map found for schema name '{self.name}'")
         return self._map
 
-    @property
-    def avsc(self) -> Optional[dict]:
-        """The Avro schema loaded from the file at `self.path`, or None if a valid file cannot be found."""
-        # if the schema has already been loaded, return it
-        if self._avsc is not None:
-            return self._avsc
+    # @property
+    # def avsc(self) -> Optional[dict]:
+    #     """The Avro schema loaded from the file at `self.path`, or None if a valid file cannot be found."""
+    #     # if the schema has already been loaded, return it
+    #     if self._avsc is not None:
+    #         return self._avsc
 
-        # if self.path does not point to an existing avro schema file, return None
-        if (self.path is None) or (self.path.suffix != ".avsc") or (not self.path.is_file()):
-            return None
+    #     # if self.path does not point to an existing avro schema file, return None
+    #     if (self.path is None) or (self.path.suffix != ".avsc") or (not self.path.is_file()):
+    #         return None
 
-        # load the schema and return it
-        self._avsc = fastavro.schema.load_schema(self.path)
-        return self._avsc
+    #     # load the schema and return it
+    #     self._avsc = fastavro.schema.load_schema(self.path)
+    #     return self._avsc
 
 
 @define(frozen=True)
 class PubsubMessageLike:
     """Container for an incoming alert.
 
+    This class is not intended to be used directly.
+    Use :class:`pittgoogle.Alert` instead.
+
+    Purpose:
     It is convenient for the :class:`pittgoogle.Alert` class to work with a message as a
-    `pubsub_v1.types.PubsubMessage`. However, there are many ways to obtain an alert that do
-    not result in a `pubsub_v1.types.PubsubMessage` (e.g., an alert packet loaded from disk or
-    an incoming message to a Cloud Functions or Cloud Run module). In those cases, this class
-    is used to create an object with the same attributes as a `pubsub_v1.types.PubsubMessage`.
-    This object is then assigned to the `msg` attribute of the `Alert`.
+    `google.cloud.pubsub_v1.types.PubsubMessage`. However, there are many ways to obtain an alert
+    that do not result in a `google.cloud.pubsub_v1.types.PubsubMessage` (e.g., an alert packet
+    loaded from disk or an incoming message to a Cloud Functions or Cloud Run module). In those
+    cases, this class is used to create an object with the same attributes as a
+    `google.cloud.pubsub_v1.types.PubsubMessage`. This object is then assigned to the `msg`
+    attribute of the `Alert`.
     """
 
     data: bytes = field()

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,13 +65,13 @@ test-all = ["astropy[test]", "coverage[toml]", "ipython (>=4.2)", "objgraph", "s
 
 [[package]]
 name = "astropy-iers-data"
-version = "0.2024.6.24.0.31.11"
+version = "0.2024.7.1.0.34.3"
 description = "IERS Earth Rotation and Leap Second tables for the astropy core package"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "astropy_iers_data-0.2024.6.24.0.31.11-py3-none-any.whl", hash = "sha256:0b3799034b0b76af8f915ef822d38cc90e00e235db0cb688018e4f567a8babb9"},
-    {file = "astropy_iers_data-0.2024.6.24.0.31.11.tar.gz", hash = "sha256:ef0197b7b84dea248031e553687ea1dc58d7ac9473043693b2d33b46d81a9a12"},
+    {file = "astropy_iers_data-0.2024.7.1.0.34.3-py3-none-any.whl", hash = "sha256:195053a2b198f964ad89440b419fa4e506d9db6a8e1cc18a387bc9c3b480a09e"},
+    {file = "astropy_iers_data-0.2024.7.1.0.34.3.tar.gz", hash = "sha256:0e3b47ae2ed44a03c3bea40a2b73bfce1858cf4059b4612c677a5e4a90f86003"},
 ]
 
 [package.extras]
@@ -306,6 +306,23 @@ files = [
 
 [package.extras]
 toml = ["tomli"]
+
+[[package]]
+name = "deprecated"
+version = "1.2.14"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "Deprecated-1.2.14-py2.py3-none-any.whl", hash = "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c"},
+    {file = "Deprecated-1.2.14.tar.gz", hash = "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"},
+]
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
 
 [[package]]
 name = "docutils"
@@ -759,6 +776,24 @@ perf = ["ipython"]
 test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
+name = "importlib-resources"
+version = "6.4.0"
+description = "Read resources from Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "importlib_resources-6.4.0-py3-none-any.whl", hash = "sha256:50d10f043df931902d4194ea07ec57960f66a80449ff867bfe782b4c486ba78c"},
+    {file = "importlib_resources-6.4.0.tar.gz", hash = "sha256:cdb2b453b8046ca4e3798eb1d84f3cce1446a0e8e7b5ef4efb600f19fc398145"},
+]
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.4"
 description = "A very fast and expressive template engine."
@@ -774,6 +809,71 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "lsst-alert-packet"
+version = "0.3.0"
+description = "Code for interacting with Vera C. Rubin Observatory alert packets"
+optional = false
+python-versions = "*"
+files = []
+develop = false
+
+[package.dependencies]
+fastavro = "*"
+lsst-resources = "*"
+numpy = "*"
+requests = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/lsst/alert_packet.git"
+reference = "w.2024.26"
+resolved_reference = "bcc3a36e4f666840ba6ad5393cef3ca78d0b3faa"
+
+[[package]]
+name = "lsst-resources"
+version = "25.2023.3000"
+description = "An abstraction layer for reading and writing from URI file resources."
+optional = false
+python-versions = "*"
+files = [
+    {file = "lsst-resources-25.2023.3000.tar.gz", hash = "sha256:870f9b6e6058b369216cb26b9a4cfc7b79853aa5fdba98c0357dfbb7fdd7d555"},
+    {file = "lsst_resources-25.2023.3000-py3-none-any.whl", hash = "sha256:7f936c13c20854b78b13ceb70f3edc1f836e34570f6e15e3ff1e036c37a12aa2"},
+]
+
+[package.dependencies]
+importlib-resources = "*"
+lsst-utils = "*"
+
+[package.extras]
+gs = ["google-cloud-storage"]
+https = ["astropy (>=4.0)", "requests (>=2.26.0)", "responses (>=0.12.0)", "urllib3 (>=1.25.10)"]
+s3 = ["backoff (>=1.10)", "boto3 (>=1.13)", "moto (>=1.3)"]
+test = ["pytest (>=3.2)", "pytest-openfiles (>=0.5.0)"]
+
+[[package]]
+name = "lsst-utils"
+version = "26.2024.1700"
+description = "Utility functions from Rubin Observatory Data Management for the Legacy Survey of Space and Time (LSST)."
+optional = false
+python-versions = ">=3.9.0"
+files = [
+    {file = "lsst_utils-26.2024.1700-py3-none-any.whl", hash = "sha256:5b24cf201e002718ec967be2025d833d23e2b9e5155622656056fe2b1082d099"},
+    {file = "lsst_utils-26.2024.1700.tar.gz", hash = "sha256:7227e350e7f042c55830f425e9692b1241184f3e6679b401dfc051a12428c1b8"},
+]
+
+[package.dependencies]
+astropy = ">=5.0"
+deprecated = ">=1.2"
+importlib-resources = "*"
+numpy = ">=1.17"
+psutil = ">=5.7"
+pyyaml = ">=5.1"
+threadpoolctl = "*"
+
+[package.extras]
+test = ["pytest (>=3.2)", "pytest-openfiles (>=0.5.0)"]
 
 [[package]]
 name = "markdown-it-py"
@@ -1105,6 +1205,35 @@ files = [
     {file = "protobuf-5.27.2-py3-none-any.whl", hash = "sha256:54330f07e4949d09614707c48b06d1a22f8ffb5763c159efd5c0928326a91470"},
     {file = "protobuf-5.27.2.tar.gz", hash = "sha256:f3ecdef226b9af856075f28227ff2c90ce3a594d092c39bee5513573f25e2714"},
 ]
+
+[[package]]
+name = "psutil"
+version = "6.0.0"
+description = "Cross-platform lib for process and system monitoring in Python."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "psutil-6.0.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a021da3e881cd935e64a3d0a20983bda0bb4cf80e4f74fa9bfcb1bc5785360c6"},
+    {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:1287c2b95f1c0a364d23bc6f2ea2365a8d4d9b726a3be7294296ff7ba97c17f0"},
+    {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:a9a3dbfb4de4f18174528d87cc352d1f788b7496991cca33c6996f40c9e3c92c"},
+    {file = "psutil-6.0.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:6ec7588fb3ddaec7344a825afe298db83fe01bfaaab39155fa84cf1c0d6b13c3"},
+    {file = "psutil-6.0.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:1e7c870afcb7d91fdea2b37c24aeb08f98b6d67257a5cb0a8bc3ac68d0f1a68c"},
+    {file = "psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35"},
+    {file = "psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1"},
+    {file = "psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e8d0054fc88153ca0544f5c4d554d42e33df2e009c4ff42284ac9ebdef4132"},
+    {file = "psutil-6.0.0-cp36-cp36m-win32.whl", hash = "sha256:fc8c9510cde0146432bbdb433322861ee8c3efbf8589865c8bf8d21cb30c4d14"},
+    {file = "psutil-6.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:34859b8d8f423b86e4385ff3665d3f4d94be3cdf48221fbe476e883514fdb71c"},
+    {file = "psutil-6.0.0-cp37-abi3-win32.whl", hash = "sha256:a495580d6bae27291324fe60cea0b5a7c23fa36a7cd35035a16d93bdcf076b9d"},
+    {file = "psutil-6.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:33ea5e1c975250a720b3a6609c490db40dae5d83a4eb315170c4fe0d8b1f34b3"},
+    {file = "psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffe7fc9b6b36beadc8c322f84e1caff51e8703b88eee1da46d1e3a6ae11b4fd0"},
+    {file = "psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2"},
+]
+
+[package.extras]
+test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
@@ -1527,6 +1656,17 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
+name = "threadpoolctl"
+version = "3.5.0"
+description = "threadpoolctl"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "threadpoolctl-3.5.0-py3-none-any.whl", hash = "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467"},
+    {file = "threadpoolctl-3.5.0.tar.gz", hash = "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1566,6 +1706,85 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "wrapt"
+version = "1.16.0"
+description = "Module for decorators, wrappers and monkey patching."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"},
+    {file = "wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136"},
+    {file = "wrapt-1.16.0-cp310-cp310-win32.whl", hash = "sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d"},
+    {file = "wrapt-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2"},
+    {file = "wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09"},
+    {file = "wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d"},
+    {file = "wrapt-1.16.0-cp311-cp311-win32.whl", hash = "sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362"},
+    {file = "wrapt-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89"},
+    {file = "wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b"},
+    {file = "wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c"},
+    {file = "wrapt-1.16.0-cp312-cp312-win32.whl", hash = "sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc"},
+    {file = "wrapt-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8"},
+    {file = "wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465"},
+    {file = "wrapt-1.16.0-cp36-cp36m-win32.whl", hash = "sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e"},
+    {file = "wrapt-1.16.0-cp36-cp36m-win_amd64.whl", hash = "sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966"},
+    {file = "wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c"},
+    {file = "wrapt-1.16.0-cp37-cp37m-win32.whl", hash = "sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c"},
+    {file = "wrapt-1.16.0-cp37-cp37m-win_amd64.whl", hash = "sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00"},
+    {file = "wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0"},
+    {file = "wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6"},
+    {file = "wrapt-1.16.0-cp38-cp38-win32.whl", hash = "sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b"},
+    {file = "wrapt-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41"},
+    {file = "wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2"},
+    {file = "wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537"},
+    {file = "wrapt-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3"},
+    {file = "wrapt-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35"},
+    {file = "wrapt-1.16.0-py3-none-any.whl", hash = "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"},
+    {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
+]
+
+[[package]]
 name = "zipp"
 version = "3.19.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1583,4 +1802,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8cca48c9ce56987e503a2f237998de4c9e2456e48bbbebcf60b40ec7d7ea0f3b"
+content-hash = "e869d348908366f4759924143ad73e5b1081aadea17d2d4df2f8a9ff04e0fa26"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ google-cloud-bigquery = ">=3.11.2"
 google-cloud-pubsub = ">=2.17.1"
 pandas = ">=1.5"  # v1.5.1 required by supernnova v3.0.1
 tabulate = ">=0.9"
+# lsst-alert-packet for the LSST schema helper.
+# The PyPI version of this looks out of date so install from a git tag instead.
+# [FIXME] This is pinned... is there a way to get the latest tag automatically?
+lsst-alert-packet = { git = "https://github.com/lsst/alert_packet.git", tag = "w.2024.26" }
 
 [tool.poetry.group.docs]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 # https://python-poetry.org/docs/dependency-specification/#git-dependencies
 python = "^3.9"
 attrs = ">=23.1"
-astropy = ">=5.3"
+astropy = ">=6.0"
 fastavro = ">=1.7.4"
 google-auth-oauthlib = ">=1.0"
 google-cloud-bigquery = ">=3.11.2"


### PR DESCRIPTION
- Add support for LSST schemas. Includes:
    - New schema helper method that uses the `lsst.alert.packet` package to load the Avro schema.
    - New yaml file defining the schema map.
- Fixup `Schema` class and related to make it easier to add new surveys and schemas in the future.
- Rename some things for clarity.

See CHANGELOG.md for more detail.