### PR TITLE
Loosen `astropy` version restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 (none)
 
+## \[v0.3.8\] - 2024-07-02
+
+### Changed
+
+- Loosen `astropy` version restriction to ">=5.3". `astropy` v<6.0.0 is required by `supernnova` v3.0.1
+  which is not a direct dependency of `pittgoogle-client` but is often used with it.
+
 ## \[v0.3.7\] - 2024-07-02
 
 ### Added

--- a/docs/source/for-developers/release-new-version.md
+++ b/docs/source/for-developers/release-new-version.md
@@ -21,13 +21,16 @@ By following these instructions, you will:
     - Under "Write", paste in the relevant section of CHANGELOG.md describing the release.
     - Click "Publish release".
 
-Completing step 3 will:
+Completing step 3 will (or should):
 
 - Tag a new version on GitHub.
 - Publish the documentation to GitHub pages.
 - Publish the package to PyPI.org.
 
-You will now be able to install the new version using:
+View the [GitHub Actions](https://github.com/mwvgroup/pittgoogle-client/actions) page to see the
+status of the release process.
+
+If all went well, you will now be able to install the new version using:
 
 ```bash
 pip install --upgrade pittgoogle-client

--- a/poetry.lock
+++ b/poetry.lock
@@ -1583,4 +1583,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f70bdbe1b9b54ce3070f89ba0206f4f11e099d15195ab353975bfa3e317ed0b4"
+content-hash = "8cca48c9ce56987e503a2f237998de4c9e2456e48bbbebcf60b40ec7d7ea0f3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 # https://python-poetry.org/docs/dependency-specification/#git-dependencies
 python = "^3.9"
 attrs = ">=23.1"
-astropy = ">=6.0"
+astropy = ">=5.3"  # v<6.0.0 required by supernnova 3.0.1
 fastavro = ">=1.7.4"
 google-auth-oauthlib = ">=1.0"
 google-cloud-bigquery = ">=3.11.2"


### PR DESCRIPTION
- Loosen `astropy` version restriction to ">=5.3". `astropy` v<6.0.0 is required by `supernnova` v3.0.1 which is not a direct dependency of `pittgoogle-client` but is often used with it.
