### PR TITLE
Add dedicated `Schema` for each survey and add support for switching serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
       switch between JSON and Avro on the fly.
     - Methods to support the LSST schema consolidation.
     - Schema map for the default schema.
- - `Topic.publish()`: new keyword arg `drop_cutouts`.
+- `Topic.publish()`: new keyword arg `drop_cutouts`.
 - Dedicated classes for all schemas, including `DefaultSchema`, `ElasticcSchema`, `LsstSchema`,
   `LvkSchema`, and `ZtfSchema`. These are subclasses of `pittgoogle.Schema`.
 - `schema.Serializers` class to hold all serializers and deserializers used by the schemas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - `Alert`:
-    - Properties: `ra`, `dec`, `name_in_bucket`.
+    - Properties: `ra`, `dec`, `healpix9`, `healpix19`, `healpix29`, `name_in_bucket`.
+    - Add healpix properties to `Alert.attributes`.
 - `Schema`:
     - Properties: `_name_in_bucket`, `serializer`, and `deserializer`. The last two can be used to
       switch between JSON and Avro on the fly.
     - Methods to support the LSST schema consolidation.
     - Schema map for the default schema.
+ - `Topic.publish()`: new keyword arg `drop_cutouts`.
 - Dedicated classes for all schemas, including `DefaultSchema`, `ElasticcSchema`, `LsstSchema`,
   `LvkSchema`, and `ZtfSchema`. These are subclasses of `pittgoogle.Schema`.
 - `schema.Serializers` class to hold all serializers and deserializers used by the schemas.
@@ -38,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
     - Consolidate LSST schemas into one. Name is "lsst".
     - Change default schema name "default_schema" -> "default".
     - `serialize` and `deserialize` methods moved to `schema.Serializers`.
+    - JSON serializer now accepts dicts containing bytes values.
+- `Topic.publish()` now handles the duties of `Alert._prep_for_publish()` (which is removed).
 - Documentation updated with new instructions for developers to implement support for a new schema.
 - Unit tests:
     - Move `conftest.SampleAlert` -> `load_data.TestAlert`
@@ -49,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 
+- `Alert._prep_for_publish()`. Equivalent functionality was added to `Topic.publish()`.
 - `SchemaHelpers` class removed. These have been promoted to full `Schema` classes.
 - `Schema._init_from_msg`. This functionality was moved to the `Schema._from_yaml` class methods.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Alert`:
     - Properties: `ra`, `dec`, `name_in_bucket`.
 - `Schema`:
-    - Property: `_name_in_bucket`.
-    - Methods to support LSST schema consolidation.
+    - Properties: `_name_in_bucket`, `serializer`, and `deserializer`. The last two can be used to
+      switch between JSON and Avro on the fly.
+    - Methods to support the LSST schema consolidation.
     - Schema map for the default schema.
+- Dedicated classes for all schemas, including `DefaultSchema`, `ElasticcSchema`, `LsstSchema`,
+  `LvkSchema`, and `ZtfSchema`. These are subclasses of `pittgoogle.Schema`.
+- `schema.Serializers` class to hold all serializers and deserializers used by the schemas.
 - Unit tests:
     - Tests for new `Alert` properties.
-    - Tests for LSST version and serialization.
+    - Tests for `Schema` and `Serializers`.
     - Randomly generated data for schema "lsst.v7_4.alert".
 - Schema maps
     - LSST support for `ssObjectId`
@@ -33,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Schema`:
     - Consolidate LSST schemas into one. Name is "lsst".
     - Change default schema name "default_schema" -> "default".
+    - `serialize` and `deserialize` methods moved to `schema.Serializers`.
+- Documentation updated with new instructions for developers to implement support for a new schema.
 - Unit tests:
     - Move `conftest.SampleAlert` -> `load_data.TestAlert`
     - Split `TestAlert` -> `TestAlertFrom`, `TestAlertProperties`, and `TestAlertMethods`
@@ -40,6 +46,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Fix issue #76. Make `Alert.dataframe` succeed even when there are no previous sources.
+
+### Removed
+
+- `SchemaHelpers` class removed. These have been promoted to full `Schema` classes.
+- `Schema._init_from_msg`. This functionality was moved to the `Schema._from_yaml` class methods.
 
 ## \[v0.3.12\] - 2025-03-07
 

--- a/docs/source/for-developers/add-new-schema-map.rst
+++ b/docs/source/for-developers/add-new-schema-map.rst
@@ -32,15 +32,16 @@ Alter the new file, keeping these important things to keep in mind:
   Broker developers to end-user scientists) to write one piece of code that can process multiple surveys.
 - The keys should be used as-is (but see below for excluding or adding keys). Changing a key's
   spelling could make things difficult for the user.
-- Our schema maps support nested fields. The values in your new yaml file should be given as strings
-  (for top-level fields) or lists of strings (for nested fields).
 - Values given in the *TEMPLATE.yml* file are only examples or descriptions and should be substituted
   with new values appropriate for the new survey.
+- Our schema maps support nested fields. The values in your yaml file should be given as strings
+  for top-level fields and lists of strings for nested fields.
 - While a key's *name* is fixed, we do not explicitly define how the key is to be interpreted --
   there is no ground-truth answer to the question, "Which LSST field should I assign as the 'flux'?".
-- Comments are left in *TEMPLATE.yml* that note the typical data types and interpretations for each field
-  to help guide your decisions.
-- Try to make decisions that result in schema maps that are conceptually consistent across surveys.
+
+    - Comments are left in *TEMPLATE.yml* that note the typical data types and interpretations for each field
+      to help guide your decisions.
+    - Try to make decisions that result in schema maps that are conceptually consistent across surveys.
 
 Excluding or adding field names (keys) from the set of Pitt-Google generics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pittgoogle/alert.py
+++ b/pittgoogle/alert.py
@@ -107,7 +107,6 @@ class Alert:
             context=context,
             schema_name=schema_name,
         )
-        alert.schema._init_from_msg(alert)
         return alert
 
     @classmethod
@@ -175,7 +174,6 @@ class Alert:
             ),
             schema_name=schema_name,
         )
-        alert.schema._init_from_msg(alert)
         return alert
 
     @classmethod
@@ -218,7 +216,6 @@ class Alert:
                 The created `Alert` object.
         """
         alert = cls(msg=msg, schema_name=schema_name)
-        alert.schema._init_from_msg(alert)
         return alert
 
     @classmethod
@@ -246,7 +243,6 @@ class Alert:
         alert = cls(
             msg=types_.PubsubMessageLike(data=bytes_), schema_name=schema_name, path=Path(path)
         )
-        alert.schema._init_from_msg(alert)
         return alert
 
     def to_mock_input(self, cloud_functions: bool = False):
@@ -373,7 +369,8 @@ class Alert:
                 If the `schema_name` is not supplied or a schema with this name is not found.
         """
         if self._schema is None:
-            self._schema = registry.Schemas.get(self.schema_name)
+            alert_bytes = self.msg.data if self.msg else None
+            self._schema = registry.Schemas.get(self.schema_name, alert_bytes=alert_bytes)
         return self._schema
 
     @property

--- a/pittgoogle/pubsub.py
+++ b/pittgoogle/pubsub.py
@@ -271,7 +271,12 @@ class Topic:
         else:
             LOGGER.info(f"deleted topic: {self.path}")
 
-    def publish(self, alert: "Alert", serializer: Literal["json", "avro", None] = None) -> int:
+    def publish(
+        self,
+        alert: "Alert",
+        serializer: Literal["json", "avro", None] = None,
+        drop_cutouts: bool = False,
+    ) -> int:
         """Publish a message with :attr:`pittgoogle.Alert.dict` as the payload and
         :attr:`pittgoogle.Alert.attributes` as the attributes.
 
@@ -281,13 +286,19 @@ class Topic:
             serializer (str or None, optional):
                 Whether to serialize the dict using Avro or JSON. If not None, this will override
                 :meth:`pittgoogle.Alert.schema.serializer` and is subject to the same conditions.
+            drop_cutouts (bool):
+                Whether to drop cutouts from the alert dict before publishing. This is useful for
+                reducing the size of the message when cutouts are not needed.
 
         Returns:
             int:
                 Pub/Sub message ID of the published message.
         """
         _serializer = serializer or alert.schema.serializer
-        message, attributes = alert._prep_for_publish(serializer=_serializer)
+        alert_dict = alert.dict if not drop_cutouts else alert.drop_cutouts()
+        message = alert.schema.serialize(alert_dict, serializer=_serializer)
+        # Pub/Sub requires attribute keys and values to be strings. Sort by key while we're at it.
+        attributes = {str(key): str(self.attributes[key]) for key in sorted(self.attributes)}
         future = self.client.publish(self.path, data=message, **attributes)
         return future.result()
 

--- a/pittgoogle/pubsub.py
+++ b/pittgoogle/pubsub.py
@@ -15,7 +15,7 @@ import datetime
 import logging
 import queue
 import time
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Literal, Optional, Union
 
 import attrs
 import attrs.validators
@@ -271,10 +271,23 @@ class Topic:
         else:
             LOGGER.info(f"deleted topic: {self.path}")
 
-    def publish(self, alert: "Alert") -> int:
+    def publish(self, alert: "Alert", serializer: Literal["json", "avro", None] = None) -> int:
         """Publish a message with :attr:`pittgoogle.Alert.dict` as the payload and
-        :attr:`pittgoogle.Alert.attributes` as the attributes."""
-        message, attributes = alert._prep_for_publish()
+        :attr:`pittgoogle.Alert.attributes` as the attributes.
+
+        Args:
+            alert (Alert):
+                The alert to be published.
+            serializer (str or None, optional):
+                Whether to serialize the dict using Avro or JSON. If not None, this will override
+                :meth:`pittgoogle.Alert.schema.serializer` and is subject to the same conditions.
+
+        Returns:
+            int:
+                Pub/Sub message ID of the published message.
+        """
+        _serializer = serializer or alert.schema.serializer
+        message, attributes = alert._prep_for_publish(serializer=_serializer)
         future = self.client.publish(self.path, data=message, **attributes)
         return future.result()
 

--- a/pittgoogle/registry_manifests/schemas.yml
+++ b/pittgoogle/registry_manifests/schemas.yml
@@ -6,7 +6,6 @@
 # - name: ''
 #   description: ''
 #   origin: 'https://...'
-#   helper: 'default_schema_helper'
 #   path: ''
 #   filter_map:
 #     1: ''
@@ -16,20 +15,17 @@
 - name: 'default'
   description: 'Default schema used when no other schema is specified.'
   origin: null
-  helper: 'default_schema_helper'
 #
 # ELASTICC alerts
 - name: 'elasticc.v0_9_1.alert'
   description: 'Avro schema of alerts published by ELAsTiCC.'
   origin: 'https://github.com/LSSTDESC/elasticc/tree/main/alert_schema'
-  helper: 'elasticc_schema_helper'
   path: 'schemas/elasticc/elasticc.v0_9_1.alert.avsc'
 #
 # ELASTICC classifications
 - name: 'elasticc.v0_9_1.brokerClassification'
   description: 'Avro schema of alerts to be sent to DESC containing classifications of ELAsTiCC alerts.'
   origin: 'https://github.com/LSSTDESC/elasticc/tree/main/alert_schema'
-  helper: 'elasticc_schema_helper'
   path: 'schemas/elasticc/elasticc.v0_9_1.brokerClassification.avsc'
 #
 # LSST alerts
@@ -37,7 +33,6 @@
   path: 'schemas/lsst/MAJOR/MINOR/lsst.vMAJOR_MINOR.alert.avsc'
   description: 'Schema for LSST alerts.'
   origin: 'https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema'
-  helper: 'lsst_schema_helper'
   filter_map:
     1: 'u'
     2: 'g'
@@ -50,14 +45,12 @@
 - name: 'lvk'
   description: 'Schema for LIGO-Virgo-KAGRA (LVK) alerts. JSON format.'
   origin: 'https://emfollow.docs.ligo.org/userguide/content.html#kafka-notice-gcn-scimma'
-  helper: 'default_schema_helper'
   path: null
 #
 # ZTF alerts
 - name: 'ztf'
   description: 'ZTF schema. The ZTF survey publishes alerts in Avro format with the schema attached in the header. Pitt-Google publishes ZTF alerts in json format. This schema covers both cases.'
   origin: 'https://zwickytransientfacility.github.io/ztf-avro-alert/schema.html'
-  helper: 'default_schema_helper'
   path: null
   filter_map:
     1: g

--- a/pittgoogle/schema.py
+++ b/pittgoogle/schema.py
@@ -3,8 +3,13 @@
 
 .. autosummary::
 
+    Serializers
     Schema
-    SchemaHelpers
+    DefaultSchema
+    ElasticcSchema
+    LsstSchema
+    LvkSchema
+    ZtfSchema
 
 ----
 """
@@ -244,14 +249,11 @@ class Schema(abc.ABC):
     """Version ID of the schema, or None. Currently only used for class:`_ConfluentWireAvroSchema`."""
     definition: dict | None = attrs.field(default=None)
     """The schema definition used to serialize and deserialize the alert bytes, if one is required."""
-    _helper: str = attrs.field(default="default_schema_helper")
-    """Name of the method in :class:`SchemaHelpers` used to load this schema."""
     path: Path | None = attrs.field(default=None)
-    """Path where the helper can find the schema, if needed."""
+    """Path to a file containing the schema definition."""
     filter_map: dict = attrs.field(factory=dict)
     """Mapping of the filter name as stored in the alert (often an int) to the common name (often a string)."""
     # The rest don't need string descriptions because we will define them as explicit properties.
-    # _map is important, but don't accept it as an init arg. We'll load it from a yaml file later.
     _map: dict | None = attrs.field(default=None, init=False)
 
     @classmethod

--- a/pittgoogle/schema.py
+++ b/pittgoogle/schema.py
@@ -70,7 +70,7 @@ class Serializers:
 
     @staticmethod
     def serialize_avro(alert_dict: dict, *, schema_definition: dict) -> bytes:
-        """Serialize `alert_dict` using the JSON format.
+        """Serialize `alert_dict` using the Avro format.
 
         Args:
             alert_dict (dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,6 @@ google-cloud-pubsub = ">=2.17.1"
 hpgeom = ">=1.3"
 pandas = ">=1.5"  # v1.5.1 required by supernnova v3.0.1
 tabulate = ">=0.9"
-# lsst-alert-packet for the LSST schema helper.
-# The PyPI version of this looks out of date so install from a git tag instead.
-# [FIXME] Can't publish to PyPI if we depend on a git repo.
-#         Without this, `schema.SchemaHelper.lsst_auto_schema_helper` won't work.
-# lsst-alert-packet = { git = "https://github.com/lsst/alert_packet.git", tag = "w.2024.26" }
 
 [tool.poetry.group.docs]
 optional = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,14 +53,23 @@ def sample_alerts_lsst() -> list[load_data.TestAlert]:
         bytes_io = io.BytesIO(alert_bytes[5:])
         alerts.append(
             load_data.TestAlert(
-                survey=survey,
                 schema_name=survey,
                 schema_version=schema_version,
+                survey=survey,
                 path=alert_path,
+                bytes_=alert_bytes,
                 dict_=fastavro.schemaless_reader(bytes_io, schema),
             )
         )
     return alerts
+
+
+@pytest.fixture
+def sample_alert_lsst_latest(sample_alerts_lsst) -> load_data.TestAlert:
+    latest_version = sorted(sa.schema_version for sa in sample_alerts_lsst)[-1]
+    for sample_alert in sample_alerts_lsst:
+        if sample_alert.schema_version == latest_version:
+            return sample_alert
 
 
 @pytest.fixture
@@ -83,6 +92,7 @@ def sample_alerts_lvk() -> list[load_data.TestAlert]:
                 schema_name=survey,
                 schema_version="UNKNOWN",
                 path=alert_path,
+                bytes_=alert_bytes,
                 dict_=json.loads(alert_bytes),
             )
         )
@@ -103,6 +113,7 @@ def sample_alerts_ztf() -> list[load_data.TestAlert]:
                 schema_name=survey,
                 schema_version=alert_path.suffixes[0].strip("."),
                 path=alert_path,
+                bytes_=alert_bytes,
                 dict_=list(fastavro.reader(io.BytesIO(alert_bytes)))[0],
             )
         )

--- a/tests/load_data.py
+++ b/tests/load_data.py
@@ -2,22 +2,30 @@ import random
 from pathlib import Path
 
 import attrs
+import yaml
 
 import pittgoogle
+
+# Load the schema manifest as a list of dicts sorted by key.
+manifest_yaml = pittgoogle.__package_path__ / "registry_manifests" / "schemas.yml"
+SCHEMA_MANIFEST = yaml.safe_load(manifest_yaml.read_text())
 
 
 @attrs.define(kw_only=True)
 class TestAlert:
     """Container for a single sample alert."""
 
-    path: Path | None = attrs.field(default=None)
-    dict_: dict | None = attrs.field(default=None)
     schema_name: str | None = attrs.field(default=None)
     schema_version: str | None = attrs.field(default=None)
     survey: str | None = attrs.field(default=None)
+    path: Path | None = attrs.field(default=None)
+    bytes_: dict | None = attrs.field(default=None)
+    dict_: dict | None = attrs.field(default=None)
 
     @property
     def pgalert(self) -> pittgoogle.Alert:
+        if self.path:
+            return pittgoogle.Alert.from_path(self.path, schema_name=self.schema_name)
         return pittgoogle.Alert.from_dict(self.dict_, schema_name=self.schema_name)
 
 

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -146,16 +146,6 @@ class TestAlertProperties:
 
 
 class TestAlertMethods:
-    def test_prep_for_publish(self, sample_alerts):
-        for sample_alert in sample_alerts:
-            alert = pittgoogle.Alert.from_path(
-                sample_alert.path, schema_name=sample_alert.schema_name
-            )
-            message, attributes = alert._prep_for_publish()
-            assert isinstance(message, bytes)
-            assert isinstance(attributes, dict)
-            assert all(isinstance(k, str) and isinstance(v, str) for k, v in attributes.items())
-
     def test_str_to_datetime(self):
         str_time = "2023-01-01T00:00:00.000000Z"
         dt = pittgoogle.Alert._str_to_datetime(str_time)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,57 @@
+# -*- coding: UTF-8 -*-
+"""Unit tests for the registry module."""
+import json
+
+import pittgoogle
+
+
+class TestSerialize:
+    def test_sample_alerts(self, sample_alerts):
+        for sample_alert in sample_alerts:
+            schema = pittgoogle.Schemas.get(
+                sample_alert.schema_name, alert_bytes=sample_alert.bytes_
+            )
+            assert isinstance(schema, pittgoogle.schema.Schema)
+
+            # Skipping json default serializer for now.
+            if schema.serializer == "json":
+                continue
+
+            # Test the default serializer.
+            serialized_dict = schema.serialize(sample_alert.dict_)
+            serialized_dict = serialized_dict.replace(b"\n", b"").replace(b" ", b"")
+            sample_alert_bytes = sample_alert.bytes_.replace(b"\n", b"").replace(b" ", b"")
+            assert serialized_dict == sample_alert_bytes
+
+            # Now switch to the non-default serializer. Need to drop cutouts.
+            cutout_keys = (
+                sample_alert.pgalert.get_key(key)
+                for key in ["cutout_difference", "cutout_science", "cutout_template"]
+            )
+            sample_alert_dict = {
+                k: v for k, v in sample_alert.dict_.items() if k not in cutout_keys
+            }
+            serialized_dict = schema.serialize(sample_alert_dict, serializer="json")
+            assert json.loads(serialized_dict) == sample_alert_dict
+
+
+class TestDeserialize:
+    def test_sample_paths(self, sample_alerts):
+        for sample_alert in sample_alerts:
+            schema = pittgoogle.Schemas.get(
+                sample_alert.schema_name, alert_bytes=sample_alert.bytes_
+            )
+            assert isinstance(schema, pittgoogle.schema.Schema)
+
+            # Test the default deserializer.
+            deserialized_bytes = schema.deserialize(sample_alert.bytes_)
+            assert deserialized_bytes == sample_alert.dict_
+
+            # Now switch to the non-default deserializer.
+            alert_dict = {"objectid": 67890, "sourceid": 1234567890}
+            if schema.deserializer == "avro":
+                alert_bytes = json.dumps(alert_dict).encode("utf-8")
+                schema.deserializer = "json"
+                deserialized_bytes = schema.deserialize(alert_bytes)
+                assert deserialized_bytes == alert_dict
+            # Skipping json -> avro for now.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -77,21 +77,21 @@ class TestCleanForJson:
         assert pittgoogle.schema.Serializers._clean_for_json(b"test") == "dGVzdA=="
 
     def test_clean_for_json_list(self):
-        input, expected_output = [1, 2.3, "test", np.nan], [1, 2.3, "test", None]
-        assert pittgoogle.schema.Serializers._clean_for_json(input) == expected_output
+        input_, expected_output = [1, 2.3, "test", np.nan], [1, 2.3, "test", None]
+        assert pittgoogle.schema.Serializers._clean_for_json(input_) == expected_output
 
     def test_clean_for_json_dict(self):
-        input = {"a": 1, "b": 2.3, "c": "test", "d": np.nan}
+        input_ = {"a": 1, "b": 2.3, "c": "test", "d": np.nan}
         expected_output = {"a": 1, "b": 2.3, "c": "test", "d": None}
-        assert pittgoogle.schema.Serializers._clean_for_json(input) == expected_output
+        assert pittgoogle.schema.Serializers._clean_for_json(input_) == expected_output
 
     def test_clean_for_json_none(self):
         assert pittgoogle.schema.Serializers._clean_for_json(None) is None
 
     def test_clean_for_json_nested(self):
-        input = {"a": [1, np.nan, {"b": b"test"}]}
+        input_ = {"a": [1, np.nan, {"b": b"test"}]}
         expected = {"a": [1, None, {"b": "dGVzdA=="}]}
-        assert pittgoogle.schema.Serializers._clean_for_json(input) == expected
+        assert pittgoogle.schema.Serializers._clean_for_json(input_) == expected
 
     def test_clean_for_json_unrecognized_type(self):
         class UnrecognizedType:


### PR DESCRIPTION
Enhancements for https://github.com/mwvgroup/Pitt-Google-Broker/pull/263.

Refactor the schemas to support switching serializers on the fly and to improve clarity and usage.

- Add schema properties `serializer` and `deserializer` to support switching between JSON and Avro on the fly.
- Add dedicated classes for all schemas, including `DefaultSchema`, `ElasticcSchema`, `LsstSchema`, `LvkSchema`, and `ZtfSchema`. These are subclasses of `pittgoogle.Schema`. These replace the `SchemaHelpers` class, which is removed.
- Add `schema.Serializers` class to hold all serializers and deserializers used by the schemas.
- Remove method `Schema._init_from_msg`. This functionality is moved to the `Schema._from_yaml` class methods.
- Update documentation with new instructions for developers to implement support for a new schema.
- Add `Alert` properties for HEALPix pixel indexes at orders 8, 19, and 29. Also add these properties to `Alert.attributes` so they are available for filtering.
- Add unit tests for `Schema` and `Serializers`.