### PR TITLE
Add ssObjectId to LSST schema map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
     - Tests for new `Alert` properties.
     - Tests for LSST version and serialization.
     - Randomly generated data for schema "lsst.v7_4.alert".
+- Schema maps
+    - LSST support for `ssObjectId`
 
 ### Changed
 

--- a/pittgoogle/schemas/maps/lsst.yml
+++ b/pittgoogle/schemas/maps/lsst.yml
@@ -5,6 +5,7 @@ SCHEMA_ORIGIN: 'https://github.com/lsst/alert_packet/tree/main/python/lsst/alert
 alertid: alertId
 sourceid: [diaSource, diaSourceId]
 objectid: [diaObject, diaObjectId]
+ssobjectid: [ssObject, ssObjectId]
 # Sources and Objects
 source: diaSource
 object: diaObject


### PR DESCRIPTION
Add support for ssObjectId to `lsst.yml`.