### PR TITLE
Add new fields to `Alert.attributes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## \[Unreleased\]
 
+## Added
+
+- `Alert`:
+    - Added the following fields to `Alert.attributes`: `prv_sources`, `prv_sources.detections`, `ssobjectid`.
+
 ### Fixed
 
 - `Topic.publish()`: Message attributes were improperly defined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - `Alert`:
     - Added the following fields to `Alert.attributes`: `n_previous_sources` and `ssobjectid`.
+- Unit tests:
+    - Tests take into account new `Alert.attributes` keys.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## Added
 
 - `Alert`:
-    - Added the following fields to `Alert.attributes`: `prv_sources`, `prv_sources.detections`, `ssobjectid`.
+    - Added the following fields to `Alert.attributes`: `n_previous_sources` and `ssobjectid`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Unit tests:
     - Tests take into account new `Alert.attributes` keys.
 
+### Changed
+
+- Rename `Alert` method `_add_id_attributes()` -> `_add_attributes()` to reflect that more properties are added.
+
 ### Fixed
 
 - `Topic.publish()`: Message attributes were improperly defined

--- a/pittgoogle/alert.py
+++ b/pittgoogle/alert.py
@@ -560,6 +560,7 @@ class Alert:
             - alertid
             - objectid
             - sourceid
+            - ssobjectid
             - healpix9
             - healpix19
             - healpix29

--- a/pittgoogle/alert.py
+++ b/pittgoogle/alert.py
@@ -270,7 +270,7 @@ class Alert:
                 self._attributes = dict(self.msg.attributes)
             else:
                 self._attributes = {}
-            self._add_id_attributes()
+            self._add_attributes()
         return self._attributes
 
     @property
@@ -553,14 +553,14 @@ class Alert:
         return self.schema._name_in_bucket(alert=self)
 
     # ---- methods ---- #
-    def _add_id_attributes(self) -> None:
-        """Add IDs and indexes to :attr:`Alert.attributes`.
+    def _add_attributes(self) -> None:
+        """Add IDs, indexes, and other properties to :attr:`Alert.attributes`.
 
         The added keys include:
-            - alertid
-            - objectid
-            - sourceid
-            - ssobjectid
+            - alertid (if defined by the survey)
+            - objectid (if defined by the survey)
+            - sourceid (if defined by the survey)
+            - ssobjectid (if defined by the survey)
             - healpix9
             - healpix19
             - healpix29

--- a/pittgoogle/alert.py
+++ b/pittgoogle/alert.py
@@ -565,8 +565,7 @@ class Alert:
             - healpix19
             - healpix29
             - schema.version
-            - prv_sources
-            - prv_sources.detections
+            - n_previous_detections
         """
         # Get the data IDs and corresponding survey-specific field names. If the field is nested, the
         # key will be a list. Join list -> string since these are likely to become Pub/Sub message attributes.
@@ -583,10 +582,7 @@ class Alert:
 
         # Add metadata.
         attributes["schema.version"] = self.schema.version
-        attributes[self.get_key("prv_sources")] = self.get("prv_sources") is not None
-        attributes[".".join([self.get_key("prv_sources"), "detections"])] = len(
-            self.get("prv_sources") or []
-        )
+        attributes["number_previous_detections"] = len(self.get("prv_sources") or [])
 
         # Add the collected attributes to self, but only if not None and don't clobber existing.
         for name, value in attributes.items():

--- a/pittgoogle/alert.py
+++ b/pittgoogle/alert.py
@@ -582,7 +582,7 @@ class Alert:
 
         # Add metadata.
         attributes["schema.version"] = self.schema.version
-        attributes["number_previous_detections"] = len(self.get("prv_sources") or [])
+        attributes["n_previous_detections"] = len(self.get("prv_sources") or [])
 
         # Add the collected attributes to self, but only if not None and don't clobber existing.
         for name, value in attributes.items():

--- a/pittgoogle/alert.py
+++ b/pittgoogle/alert.py
@@ -564,10 +564,12 @@ class Alert:
             - healpix19
             - healpix29
             - schema.version
+            - prv_sources
+            - prv_sources.detections
         """
         # Get the data IDs and corresponding survey-specific field names. If the field is nested, the
         # key will be a list. Join list -> string since these are likely to become Pub/Sub message attributes.
-        ids = ["alertid", "objectid", "sourceid"]
+        ids = ["alertid", "objectid", "sourceid", "ssobjectid"]
         _names = [self.get_key(id) for id in ids]
         names = [".".join(id) if isinstance(id, list) else id for id in _names]
         values = [self.get(id) for id in ids]
@@ -580,6 +582,10 @@ class Alert:
 
         # Add metadata.
         attributes["schema.version"] = self.schema.version
+        attributes[self.get_key("prv_sources")] = self.get("prv_sources") is not None
+        attributes[".".join([self.get_key("prv_sources"), "detections"])] = len(
+            self.get("prv_sources") or []
+        )
 
         # Add the collected attributes to self, but only if not None and don't clobber existing.
         for name, value in attributes.items():

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -36,10 +36,12 @@ class TestAlertFrom:
             )
             # We expect that the following keys were added to alert.attributes.
             #  to  alertid, objectid, sourceid, and schema version should have been added as attributes.
-            _id_keys = (alert.get_key(key) for key in ["alertid", "objectid", "sourceid"])
+            _id_keys = (
+                alert.get_key(key) for key in ["alertid", "objectid", "sourceid", "ssobjectid"]
+            )
             id_keys = [".".join(key) if isinstance(key, list) else key for key in _id_keys]
             index_keys = ["healpix9", "healpix19", "healpix29"]
-            metadata_keys = ["schema.version"]
+            metadata_keys = ["schema.version", "n_previous_detections"]
             # 'if key' to drop None.
             expected_keys = set(key for key in id_keys + index_keys + metadata_keys if key)
             assert set(alert.attributes) == expected_keys

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -35,7 +35,7 @@ class TestAlertFrom:
                 test_alert.dict_, schema_name=test_alert.schema_name
             )
             # We expect that the following keys were added to alert.attributes.
-            #  to  alertid, objectid, sourceid, and schema version should have been added as attributes.
+            #  to  alertid, objectid, sourceid, ssobjectid, and schema version should have been added as attributes.
             _id_keys = (
                 alert.get_key(key) for key in ["alertid", "objectid", "sourceid", "ssobjectid"]
             )


### PR DESCRIPTION
Adds the following fields to `Alert.attributes`: `n_previous_detections`, `ssobjectid`.