### PR TITLE
Update key names for Alert.attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## \[Unreleased\]
 
-(none)
+### Changed
+
+- `Alert`:
+    - Updated the separator `"."` -> `"_"` used to define attribute key names.
 
 ## \[v0.3.14\] - 2025-04-28
 

--- a/pittgoogle/alert.py
+++ b/pittgoogle/alert.py
@@ -574,7 +574,7 @@ class Alert:
         # key will be a list. Join list -> string since these are likely to become Pub/Sub message attributes.
         ids = ["alertid", "objectid", "sourceid", "ssobjectid"]
         _names = [self.get_key(id) for id in ids]
-        names = [".".join(id) if isinstance(id, list) else id for id in _names]
+        names = ["_".join(id) if isinstance(id, list) else id for id in _names]
         values = [self.get(id) for id in ids]
         attributes = dict(zip(names, values))
 
@@ -584,7 +584,7 @@ class Alert:
         attributes["healpix29"] = self.healpix29
 
         # Add metadata.
-        attributes["schema.version"] = self.schema.version
+        attributes["schema_version"] = self.schema.version
         attributes["n_previous_detections"] = len(self.get("prv_sources") or [])
 
         # Add the collected attributes to self, but only if not None and don't clobber existing.

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -39,9 +39,9 @@ class TestAlertFrom:
             _id_keys = (
                 alert.get_key(key) for key in ["alertid", "objectid", "sourceid", "ssobjectid"]
             )
-            id_keys = [".".join(key) if isinstance(key, list) else key for key in _id_keys]
+            id_keys = ["_".join(key) if isinstance(key, list) else key for key in _id_keys]
             index_keys = ["healpix9", "healpix19", "healpix29"]
-            metadata_keys = ["schema.version", "n_previous_detections"]
+            metadata_keys = ["schema_version", "n_previous_detections"]
             # 'if key' to drop None.
             expected_keys = set(key for key in id_keys + index_keys + metadata_keys if key)
             assert set(alert.attributes) == expected_keys


### PR DESCRIPTION
This PR updates the separator `"."` -> `"_"` used to define attribute key names.