### PR TITLE
Add `LvkSchema._name_in_bucket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - Data listings for LSST
+- `LvkSchema` properties `_from_yaml` and `_name_in_bucket`.
+- "objectid" added to LVK schema map. Both "objectid" and "sourceid" now point to the
+  LVK field "superevent_id" since there is no distinction between an LVK "object" and "source".
+- Added a unit test for `LvkSchema._name_in_bucket`. Added a "schema_version" field to the test data in
+  tests/data/sample_alerts/lvk/ to mimic our broker's ps_to_storage module (required for `_name_in_bucket`).
 
 ## \[v0.3.15\] - 2025-05-12
 

--- a/pittgoogle/schema.py
+++ b/pittgoogle/schema.py
@@ -313,7 +313,7 @@ class Schema(abc.ABC):
         """
 
     @abc.abstractmethod
-    def _name_in_bucket(_alert: "Alert") -> None:
+    def _name_in_bucket(_alert: "Alert") -> str:
         """Construct the name of the Google Cloud Storage object."""
 
     @property
@@ -595,7 +595,8 @@ class LsstSchema(Schema):
         )
 
     @staticmethod
-    def _name_in_bucket(alert: "Alert"):
+    def _name_in_bucket(alert: "Alert") -> str:
+        """Construct the name of the Google Cloud Storage object."""
         if alert.schema.version is None:
             raise exceptions.SchemaError(
                 "No version information available. Cannot construct object name."

--- a/pittgoogle/schema.py
+++ b/pittgoogle/schema.py
@@ -611,6 +611,34 @@ class LsstSchema(Schema):
 class LvkSchema(DefaultSchema):
     """Schema for LVK alerts."""
 
+    @classmethod
+    def _from_yaml(cls, yaml_dict: dict, *, alert_bytes: bytes | None = None) -> "Schema":
+        """Create a schema object from `yaml_dict`.
+
+        Args:
+            yaml_dict (dict):
+                A dictionary containing the schema information, loaded from the registry's 'schemas.yml' file.
+            alert_bytes (bytes or None, optional):
+                Message data. This is needed in order to get the schema version. If not provided, methods
+                such as :meth:`LvkSchema._name_in_bucket` will raise a :class:`pittgoogle.exceptions.SchemaError`.
+
+        Returns:
+            Schema
+        """
+        schema = super()._from_yaml(yaml_dict)
+        alert_dict = Serializers.deserialize_json(alert_bytes or b"{}")
+        schema.version = alert_dict.get("schema_version")
+        return schema
+
+    @staticmethod
+    def _name_in_bucket(alert: "Alert") -> "str":
+        """Construct the name of the Google Cloud Storage object."""
+        if alert.schema.version is None:
+            raise exceptions.SchemaError("Schema version not found. Cannot construct object name.")
+
+        filename = f"{alert.dict['alert_type']}-{alert.dict['time_created'][0:10]}.json"
+        return f"{alert.schema.version}/{alert.get_key('objectid')}={alert.objectid}/{filename}"
+
 
 @attrs.define(kw_only=True)
 class ZtfSchema(DefaultSchema):

--- a/pittgoogle/schemas/maps/lvk.yml
+++ b/pittgoogle/schemas/maps/lvk.yml
@@ -3,6 +3,7 @@ SCHEMA_ORIGIN: 'https://emfollow.docs.ligo.org/userguide/content.html#kafka-noti
 #
 # IDs.
 alertid: superevent_id  # str
+objectid: superevent_id  # str
 sourceid: superevent_id  # str
 #
 # Sources and Objects

--- a/tests/data/sample_alerts/lvk/MS181101ab-earlywarning.json
+++ b/tests/data/sample_alerts/lvk/MS181101ab-earlywarning.json
@@ -1,4 +1,5 @@
 {
+    "schema_version": "v1_0",
     "alert_type": "EARLYWARNING",
     "time_created": "2018-11-01T22:34:20Z",
     "superevent_id": "MS181101ab",

--- a/tests/data/sample_alerts/lvk/MS181101ab-ext-update.json
+++ b/tests/data/sample_alerts/lvk/MS181101ab-ext-update.json
@@ -1,4 +1,5 @@
 {
+    "schema_version": "v1_0",
     "alert_type": "UPDATE",
     "time_created": "2018-11-01T22:36:25Z",
     "superevent_id": "MS181101ab",

--- a/tests/data/sample_alerts/lvk/MS181101ab-initial.json
+++ b/tests/data/sample_alerts/lvk/MS181101ab-initial.json
@@ -1,4 +1,5 @@
 {
+    "schema_version": "v1_0",
     "alert_type": "INITIAL",
     "time_created": "2018-11-01T22:36:25Z",
     "superevent_id": "MS181101ab",

--- a/tests/data/sample_alerts/lvk/MS181101ab-preliminary.json
+++ b/tests/data/sample_alerts/lvk/MS181101ab-preliminary.json
@@ -1,4 +1,5 @@
 {
+    "schema_version": "v1_0",
     "alert_type": "PRELIMINARY",
     "time_created": "2018-11-01T22:34:49Z",
     "superevent_id": "MS181101ab",

--- a/tests/data/sample_alerts/lvk/MS181101ab-retraction.json
+++ b/tests/data/sample_alerts/lvk/MS181101ab-retraction.json
@@ -1,4 +1,5 @@
 {
+    "schema_version": "v1_0",
     "alert_type": "RETRACTION",
     "time_created": "2018-11-01T23:36:23Z",
     "superevent_id": "MS181101ab",

--- a/tests/data/sample_alerts/lvk/MS181101ab-update.json
+++ b/tests/data/sample_alerts/lvk/MS181101ab-update.json
@@ -1,4 +1,5 @@
 {
+    "schema_version": "v1_0",
     "alert_type": "UPDATE",
     "time_created": "2018-11-01T22:36:25Z",
     "superevent_id": "MS181101ab",

--- a/tests/data/sample_alerts/lvk/README.md
+++ b/tests/data/sample_alerts/lvk/README.md
@@ -1,3 +1,4 @@
 # LVK Sample Alerts
 
 Downloaded from <https://emfollow.docs.ligo.org/userguide/tutorial/receiving/gcn.html#examples>.
+A "schema_version" field was added to mimic our broker's ps_to_storage module.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -99,3 +99,18 @@ class TestCleanForJson:
 
         with pytest.raises(TypeError):
             pittgoogle.schema.Serializers._clean_for_json(UnrecognizedType())
+
+
+class TestLvkSchema:
+    def test_name_in_bucket(self, sample_alerts_lvk):
+        for sample_alert in sample_alerts_lvk:
+            alert = sample_alert.pgalert
+            filename = alert.schema._name_in_bucket(alert=alert)
+            assert isinstance(filename, str)
+            assert filename.startswith("v")
+            assert len(filename.split("/")) == 3
+            assert filename.endswith(".json")
+
+        alert.schema.version = None
+        with pytest.raises(pittgoogle.exceptions.SchemaError):
+            alert.schema._name_in_bucket(alert=alert)


### PR DESCRIPTION
Caused by https://github.com/mwvgroup/Pitt-Google-Broker/pull/290. 

- Add `LvkSchema` methods.
- Add a unit test for `LvkSchema._name_in_bucket`. Also add a "schema_version" field to the LVK test data to mimic our broker's ps_to_storage module and facilitate the unit test.